### PR TITLE
I had to define S_ISREG in order to compile on my machine

### DIFF
--- a/src/tpl.c
+++ b/src/tpl.c
@@ -53,6 +53,9 @@ typedef unsigned __int32 uint32_t;
 typedef unsigned __int64 uint64_t;
 #endif
 
+#ifndef S_ISREG
+#define S_ISREG(mode)  (((mode) & S_IFMT) == S_IFREG)
+#endif
 
 #if ( defined __CYGWIN__ || defined __MINGW32__ || defined _WIN32 )
 #include "win/mman.h"   /* mmap */


### PR DESCRIPTION
I do not use that part of code, so I don't know if this is OK, but I had to add it to compile so that I can use the library.
- required for VC80 with Microsoft SDK 7.1
