### PR TITLE
Clean up of warnings (tested on clang).

### DIFF
--- a/src/tpl.h
+++ b/src/tpl.h
@@ -120,12 +120,12 @@ TPL_API tpl_node *tpl_map(char *fmt,...);       /* define tpl using format */
 TPL_API void tpl_free(tpl_node *r);             /* free a tpl map */
 TPL_API int tpl_pack(tpl_node *r, int i);       /* pack the n'th packable */
 TPL_API int tpl_unpack(tpl_node *r, int i);     /* unpack the n'th packable */
-TPL_API ssize_t tpl_dump(tpl_node *r, int mode, ...); /* serialize to mem/file */
+TPL_API int tpl_dump(tpl_node *r, int mode, ...); /* serialize to mem/file */
 TPL_API int tpl_load(tpl_node *r, int mode, ...); /* set mem/file to unpack */
 TPL_API int tpl_Alen(tpl_node *r, int i);      /* array len of packable i */
 TPL_API char* tpl_peek(int mode, ...);         /* sneak peek at format string */
 TPL_API int tpl_gather( int mode, ...);        /* non-blocking image gather */
-TPL_API ssize_t tpl_jot(int mode, ...);            /* quick write a simple tpl */
+TPL_API int tpl_jot(int mode, ...);            /* quick write a simple tpl */
 
 TPL_API tpl_node *tpl_map_va(char *fmt, va_list ap);
 


### PR DESCRIPTION
I tried to cleanup all of the warnings for implicit conversions. I understand that it can be a non-trivial task, for the formability issues related to type conversion can be hard to spot at a first look on the code. For this reason, I am not 100% sure I've done all the necessary edits to your code.
Nonetheless, I think that checking and cleaning up type conversion warnings would be a desirable task, giving users some larger confidence in the code reliability.

Of course, thanks for sharing such a helpful piece of software.
